### PR TITLE
Allow landing-page-only deploys without a database

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,3 @@
-// import SignInButton from '@/components/SignInButton';
-import { getAuthSession } from '@/lib/nextauth';
-import { redirect } from 'next/navigation';
 import Link from "next/link"
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card"
 import { Brain, Clock, Users, TrendingUp, Coins, Eye, Wallet } from "lucide-react"
@@ -9,9 +6,16 @@ import { Badge } from '@/components/ui/badge';
 import Image from 'next/image';
 
 export default async function Home() {
-  const session = await getAuthSession()
-  if (session?.user) {
-    redirect('/dashboard')
+  if (process.env.DATABASE_URL?.trim()) {
+    const [{ getAuthSession }, { redirect }] = await Promise.all([
+      import('@/lib/nextauth'),
+      import('next/navigation'),
+    ]);
+    const session = await getAuthSession();
+
+    if (session?.user) {
+      redirect('/dashboard');
+    }
   }
 
   return (

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",
-    "build": "npx prisma migrate deploy && npx prisma generate && next build",
+    "build": "node scripts/build-with-optional-db.mjs",
     "db:setup": "npx prisma migrate deploy",
-    "postinstall": "npx prisma generate",
+    "postinstall": "node scripts/prisma-generate-if-needed.mjs",
     "start": "next start",
     "lint": "next lint",
     "start:server": "ts-node -r tsconfig-paths/register --project tsconfig.server.json server/index.ts"

--- a/scripts/build-with-optional-db.mjs
+++ b/scripts/build-with-optional-db.mjs
@@ -1,0 +1,42 @@
+import { spawnSync } from "node:child_process";
+import nextEnv from "@next/env";
+
+// Allow Vercel builds to succeed while the production DB is paused.
+// When DATABASE_URL is present, run the normal Prisma migrate/generate flow.
+// When it is missing or empty, skip migrations and use a placeholder URL so
+// Prisma can still generate the client for the landing-page-only deployment.
+const { loadEnvConfig } = nextEnv;
+loadEnvConfig(process.cwd());
+
+const placeholderDatabaseUrl =
+  "postgresql://placeholder:placeholder@127.0.0.1:5432/intelli_casino";
+
+function run(command, args, env = process.env) {
+  const result = spawnSync(command, args, {
+    stdio: "inherit",
+    env,
+  });
+
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1);
+  }
+}
+
+const hasDatabaseUrl = Boolean(process.env.DATABASE_URL?.trim());
+const env = {
+  ...process.env,
+  DATABASE_URL: hasDatabaseUrl
+    ? process.env.DATABASE_URL
+    : placeholderDatabaseUrl,
+};
+
+if (hasDatabaseUrl) {
+  run("npx", ["prisma", "migrate", "deploy"], env);
+} else {
+  console.warn(
+    "DATABASE_URL is not configured. Skipping Prisma migrations and building landing page only."
+  );
+}
+
+run("npx", ["prisma", "generate"], env);
+run("next", ["build"], env);

--- a/scripts/prisma-generate-if-needed.mjs
+++ b/scripts/prisma-generate-if-needed.mjs
@@ -1,0 +1,31 @@
+import { spawnSync } from "node:child_process";
+import nextEnv from "@next/env";
+
+// Postinstall can run before the main build script, so it needs the same
+// empty-DATABASE_URL fallback. This keeps prisma generate from failing during
+// installs when the app is intentionally deployed without a live database.
+const { loadEnvConfig } = nextEnv;
+loadEnvConfig(process.cwd());
+
+const placeholderDatabaseUrl =
+  "postgresql://placeholder:placeholder@127.0.0.1:5432/intelli_casino";
+
+const env = {
+  ...process.env,
+  DATABASE_URL: process.env.DATABASE_URL?.trim() || placeholderDatabaseUrl,
+};
+
+if (!process.env.DATABASE_URL?.trim()) {
+  console.warn(
+    "DATABASE_URL is not configured. Generating Prisma client with a placeholder URL."
+  );
+}
+
+const result = spawnSync("npx", ["prisma", "generate"], {
+  stdio: "inherit",
+  env,
+});
+
+if (result.status !== 0) {
+  process.exit(result.status ?? 1);
+}


### PR DESCRIPTION
## Summary

This changes the build flow so Vercel can still deploy the landing page when `DATABASE_URL` is missing or intentionally unset.

## What changed

- wrap the Prisma build steps in a conditional build script
- skip `prisma migrate deploy` when `DATABASE_URL` is missing or empty
- use a placeholder Postgres URL for `prisma generate` so Prisma schema validation still passes
- add the same fallback to `postinstall`, since Prisma generate can run before the main build
- update the homepage to only import auth and redirect signed-in users when `DATABASE_URL` is present
- keep local behavior intact when a real database is configured

## Why

The production DB is currently paused. Without this change, Vercel build fails before `next build` because Prisma requires a non-empty `DATABASE_URL`.

This allows a temporary landing-page-only deployment while leaving the rest of the app dormant until the DB is restored.

## Expected behavior

- with `DATABASE_URL` set:
  - build runs Prisma migrations and generate normally
  - homepage checks session and redirects signed-in users to `/dashboard`
- with `DATABASE_URL` missing or empty:
  - build skips Prisma migrations
  - Prisma client generation uses a placeholder URL
  - homepage renders without importing auth or touching Prisma

## What to verify

- Vercel branch deployment succeeds with `DATABASE_URL` unset
- landing page loads successfully
- build logs show the fallback path was used
- no auth/db-backed routes are expected to work until the real DB is restored

## Notes

This is a temporary pause-mode workaround, not a full removal of Prisma or auth. Once the production DB is restored, normal app behavior should resume with `DATABASE_URL` set again.